### PR TITLE
Filter `Homebrew.deps_for_formula` to leave only Dependency

### DIFF
--- a/cmd/brew-rmtree.rb
+++ b/cmd/brew-rmtree.rb
@@ -156,7 +156,8 @@ module BrewRmtree
   # Gather complete list of packages used by root package
   def dependency_tree(keg_name, recursive=true)
     Homebrew.deps_for_formula(as_formula(keg_name), recursive
-      ).select(&:installed?
+      ).select{|dep| dep.is_a? Dependency
+      }.select(&:installed?
       )#.sort_by(&:name)
   end
 


### PR DESCRIPTION
Homebrew.deps_for_formula() result may include special dependencies (requirements), that don't implement `installed?` method: https://github.com/Homebrew/brew/blob/e3226638365713b7f9ea45f8a63322baa7dd1941/Library/Homebrew/dependency_collector.rb#L107

fixes #18