### PR TITLE
fix(main): replace ARGV with Homebrew.args

### DIFF
--- a/cmd/brew-rmtree.rb
+++ b/cmd/brew-rmtree.rb
@@ -504,7 +504,7 @@ module BrewRmtree
       abort `brew rmtree --help`
     end
 
-    raise KegUnspecifiedError if ARGV.named.empty?
+    raise KegUnspecifiedError if Homebrew.args.no_named?
 
     loop { case ARGV[0]
         when '--quiet' then ARGV.shift; quiet = true


### PR DESCRIPTION
closes #35 

Homebrew deprecates `ARGV.named` with `Homebrew.args.named` in version 2.2.2 https://github.com/Homebrew/brew/pull/6840, and since 2.2.10 https://github.com/Homebrew/brew/pull/7120 it provides [`no_named?`]() method to check whether `named` is nil or not.

@beeftornado 