### PR TITLE
Fix rmtree command for linux

### DIFF
--- a/cmd/brew-rmtree.rb
+++ b/cmd/brew-rmtree.rb
@@ -67,7 +67,7 @@ module BrewRmtree
     if brew_home.directory?
       brew_bin = brew_home / "bin/brew"
       if brew_bin.executable?
-        return brew_bin.realpath
+        return brew_bin.to_s
       end
     end
     return "brew"


### PR DESCRIPTION
Sadly `rmtree` command is broken for linux. So I propose the fix. 

Default linux path for brew is `/home/linuxbrew/.linuxbrew/bin/brew` , which is a symlink to `../Homebrew/bin/brew` . 
Using `realpath` resolves symlink on linux which leads to wrong keg paths. So basically  `m` command looks like: `home/linuxbrew/.linuxbrew/Homebrew/bin/brew rm keg` , but it must be `/home/linuxbrew/.linuxbrew/bin/brew rm keg` 

On MacOS the brew command is not a symlink `ls -l /opt/homebrew/bin/brew` and it works fine. 
Let me know if you have questions or any other assistance. 