### PR TITLE
Add --include-implicit option for brew 4.4.15

### DIFF
--- a/cmd/rmtree.rb
+++ b/cmd/rmtree.rb
@@ -49,6 +49,9 @@ module Homebrew
               "formula's children. If 'ruby' depends on 'git', then 'git' will still not be removed. Sorry."
         comma_array "--ignore=",
               description: "Ignore some dependencies from being removed. Specify multiple values separated by a comma."
+        switch "--include-implicit",
+               hidden: true,
+               description: "Include `:implicit` dependencies for <formula>."
         switch "--include-build",
               hidden: true,
               description: "Include `:build` dependencies for <formula>."


### PR DESCRIPTION
Add `--include-implicit` option for compatibility with brew 4.4.15.

Issue: https://github.com/beeftornado/homebrew-rmtree/issues/65
brew PR: https://github.com/Homebrew/brew/pull/19000

I'm not entirely sure if this is the best way to fix it, so any feedback would be appreciated! Thanks! 🙏